### PR TITLE
AN/ARC-186 Fix AM/FM/Man/Pre switch

### DIFF
--- a/Cockpit/Scripts/ARC186/device/ARC186.lua
+++ b/Cockpit/Scripts/ARC186/device/ARC186.lua
@@ -199,9 +199,9 @@ function update()
         elseif freqSelectIndex == 1 then
             frequency = 121.5e6
             -- TODO AM Modulation
-        elseif freqSelectIndex == 3 then
+        elseif freqSelectIndex == 2 then
             frequency = freq10MHz * 10e6 + freq1MHz * 1e6 + freq100KHz * 100e3 + freq25KHz * 25e3
-        elseif freqSelectIndex == 4 then
+        elseif freqSelectIndex == 3 then
             if presets[presetIndex] then
                 frequency = presets[presetIndex] * 1e6
             else

--- a/Cockpit/Scripts/ASN128/device/table.lua
+++ b/Cockpit/Scripts/ASN128/device/table.lua
@@ -32,7 +32,7 @@ data =
                 paramHandleString = "ASN128_CURRENT_WP",
                 inputData = "",
                 updateInputData = function(input)
-                    data.pages[50][1].inputData = formatPrecedingZeros(waypoints[currWP].number, 2)..":"..input
+                    data.pages[50][1].inputData = formatPrecedingZeros(waypoints[currTGTWP].number, 2)..":"..input
                 end,
             },
             [2] =
@@ -162,7 +162,7 @@ data =
                 paramHandleString = "ASN128_CURRENT_WP",
                 inputData = "",
                 updateInputData = function(input)
-                    data.pages[51][1].inputData = formatPrecedingZeros(waypoints[currWP].number, 2)..":"..input
+                    data.pages[51][1].inputData = formatPrecedingZeros(waypoints[currTGTWP].number, 2)..":"..input
                 end,
             },
             [2] = {

--- a/Cockpit/Scripts/Systems/lighting.lua
+++ b/Cockpit/Scripts/Systems/lighting.lua
@@ -359,7 +359,7 @@ function SetCommand(command,value)
 		fuelProbeSwitchState = 1 - fuelProbeSwitchState
 	elseif command == Keys.formationLightsInc and  formationBrightness < 1 then
 		dev:performClickableAction(device_commands.formationLights, clamp(formationBrightness + 0.2, 0, 1), false)
-	elseif command == Keys.formationLightsDec and formationBrightness < 0 then
+	elseif command == Keys.formationLightsDec and formationBrightness > 0 then
 		dev:performClickableAction(device_commands.formationLights, clamp(formationBrightness - 0.2, 0, 1), false)
 	elseif command == Keys.glareshieldLightsInc and glareShieldLightBrightness < 1 then 
 		dev:performClickableAction(device_commands.glareshieldLights, clamp(glareShieldLightBrightness + value*4, 0, 1), false)


### PR DESCRIPTION
Repaired functionality of the AM/FM/Man/Pre switch by correcting the numbering used in the if statements for freqSelectIndex. It previously was 0,1,3,4 and was corrected to 0,1,2,3.

This fixes the following issues:
#201 #189 