### PR TITLE
ASN-128B Fix waypoint decrement wraparound

### DIFF
--- a/Cockpit/Scripts/ASN128/device/ASN128.lua
+++ b/Cockpit/Scripts/ASN128/device/ASN128.lua
@@ -269,7 +269,7 @@ function buttonFunctions(command)
                 if (currWP > 1) then
                     currWP = currWP - 1
                 else
-                    currWP = 70
+                    currWP = 100
                 end
             end
         end


### PR DESCRIPTION
Decrementing waypoints below 0 was causing waypoint to wrap around to 69, but should instead be 99. Fixed currWP value when decrementing if currWP <1 by changing from 70 to 100.

Fixes issue:
#136 