### PR TITLE
AN/ASN-128 Edit Waypoint Fix

### DIFF
--- a/Cockpit/Scripts/ASN128/device/table.lua
+++ b/Cockpit/Scripts/ASN128/device/table.lua
@@ -32,7 +32,7 @@ data =
                 paramHandleString = "ASN128_CURRENT_WP",
                 inputData = "",
                 updateInputData = function(input)
-                    data.pages[50][1].inputData = formatPrecedingZeros(waypoints[currWP].number, 2)..":"..input
+                    data.pages[50][1].inputData = formatPrecedingZeros(waypoints[currTGTWP].number, 2)..":"..input
                 end,
             },
             [2] =
@@ -162,7 +162,7 @@ data =
                 paramHandleString = "ASN128_CURRENT_WP",
                 inputData = "",
                 updateInputData = function(input)
-                    data.pages[51][1].inputData = formatPrecedingZeros(waypoints[currWP].number, 2)..":"..input
+                    data.pages[51][1].inputData = formatPrecedingZeros(waypoints[currTGTWP].number, 2)..":"..input
                 end,
             },
             [2] = {


### PR DESCRIPTION
Bug while editing waypoints caused the currently active waypoint to always be edited instead of the selected waypoint. Changed updateInputData to use currTGTWP instead of currWP.

Fixes issue:
#174 