### PR TITLE
AN/ARC-186 Fix AM/FM/Man/Pre switch

### DIFF
--- a/Cockpit/Scripts/ARC186/device/ARC186.lua
+++ b/Cockpit/Scripts/ARC186/device/ARC186.lua
@@ -199,9 +199,9 @@ function update()
         elseif freqSelectIndex == 1 then
             frequency = 121.5e6
             -- TODO AM Modulation
-        elseif freqSelectIndex == 3 then
+        elseif freqSelectIndex == 2 then
             frequency = freq10MHz * 10e6 + freq1MHz * 1e6 + freq100KHz * 100e3 + freq25KHz * 25e3
-        elseif freqSelectIndex == 4 then
+        elseif freqSelectIndex == 3 then
             if presets[presetIndex] then
                 frequency = presets[presetIndex] * 1e6
             else


### PR DESCRIPTION
Repaired functionality of the AM/FM/Man/Pre switch by correcting the numbering used in the if statements for freqSelectIndex. It previously was 0,1,3,4 and was corrected to 0,1,2,3.

This fixes the following issues:
#201  #189 