### PR TITLE
Fix AN/ASN-128 stuck knob

### DIFF
--- a/Cockpit/Scripts/ASN128/device/ASN128.lua
+++ b/Cockpit/Scripts/ASN128/device/ASN128.lua
@@ -207,9 +207,16 @@ function selectDisplay(value)
     moreTextHandle:set("more")
     endTextHandle:set("end")
     inputArray = {}
-    if powerUpMode then return end
 
     displayIndex = math.ceil(value * 100)
+	
+    -- This mostly works, except for certain edge cases, but at least is recoverable
+    if powerUpMode then 
+	displayIndex = displayIndex*10
+	return
+    end
+
+    
     
     if (modeIndex == 3 or modeIndex == 4) then
         if displayIndex == 0 then
@@ -227,6 +234,9 @@ function selectDisplay(value)
         elseif displayIndex == 6 then
             changePage(DATUMROUTE_1)
         end
+    -- Temp solution to keep the keyboard/joystick keybinds functioning
+    elseif (modeIndex == 0 or modeIndex == 1 or modeIndex == 2 or modeIndex == 5) then
+	displayIndex = displayIndex*10
     end
 end
 

--- a/Cockpit/Scripts/ASN128/device/ASN128.lua
+++ b/Cockpit/Scripts/ASN128/device/ASN128.lua
@@ -215,8 +215,6 @@ function selectDisplay(value)
 	displayIndex = displayIndex*10
 	return
     end
-
-    
     
     if (modeIndex == 3 or modeIndex == 4) then
         if displayIndex == 0 then
@@ -234,7 +232,7 @@ function selectDisplay(value)
         elseif displayIndex == 6 then
             changePage(DATUMROUTE_1)
         end
-    -- Temp solution to keep the keyboard/joystick keybinds functioning
+    -- Temp solution to keep the keyboard/joystick keybinds functioning withough calling changePage()
     elseif (modeIndex == 0 or modeIndex == 1 or modeIndex == 2 or modeIndex == 5) then
 	displayIndex = displayIndex*10
     end


### PR DESCRIPTION
This is not a fully functional fix due to a few edge cases, but the knob will no longer end up completely stuck. This breaks down when for example the display knob is set to position 3 (PP), and the mode switch is moved to position 0 (off) then to position 3 (MGRS), then not pressing enter to make the system operational. In this specific configuration using the keybind to increase the display knob will fail because now displayIndex = 100 (increase keybind requres displayIndex < 60). Using the keybind to decrease the knob will snap the knob to position 6 (GPS LDG). Fully resolving this will probably require some amount of rewrite, or a clever solution that I am unable to think of. In the meantime this is workable.

Mostly fixes issue:
#191 