### PR TITLE
Fix HSI/VSI Course Deviation

### DIFF
--- a/Cockpit/Scripts/CISP/device/core.lua
+++ b/Cockpit/Scripts/CISP/device/core.lua
@@ -100,15 +100,15 @@ flagMoveSpeed = 5
 
 -- Corrects course error to account for travel towards or away (keeps value between +90 & -90)
 function trackErrorRotationalSymmetry(trackError)
-	if trackError > 90 then -- We're flying opposite the course needle
-		trackError = -trackError + 180 -- Invert the error so instrument reads correctly
-		return trackError
-	elseif trackError < -90  then -- We're flying opposite the course needle
-		trackError = -trackError - 180 -- Invert the error so instrument reads correctly
-		return trackError
-	else -- We're flying towards the ILS/course needle, no change needed
-		return trackError
-	end
+    if trackError > 90 then -- We're flying opposite the course needle
+        trackError = -trackError + 180 -- Invert the error so instrument reads correctly
+        return trackError
+    elseif trackError < -90  then -- We're flying opposite the course needle
+        trackError = -trackError - 180 -- Invert the error so instrument reads correctly
+        return trackError
+    else -- We're flying towards the ILS/course needle, no change needed
+        return trackError
+    end
 end
 
 function getBeaconData(freq, type)
@@ -254,23 +254,23 @@ function updateVORILS()
 
                     -- Set track error
                     rawTrackError = getShortestRadialPath(vorILSBearing, ilsDirection) -- Error between -180 and +180
-					vorILSTrackError = trackErrorRotationalSymmetry(rawTrackError) -- Error between -90 and +90, for instruments
-					if rawTrackError ~= vorILSTrackError then
-						vorDirFlag = -1 -- We're moving away, set direction flag
-					else
-						vorDirFlag = 1 -- We're moving towards, set direction flag
-					end
+                    vorILSTrackError = trackErrorRotationalSymmetry(rawTrackError) -- Error between -90 and +90, for instruments
+                    if rawTrackError ~= vorILSTrackError then
+                        vorDirFlag = -1 -- We're moving away, set direction flag
+                    else
+                        vorDirFlag = 1 -- We're moving towards, set direction flag
+                    end
                 else
                     validVOR = true
 					
-					-- Set track error, same as above but for `course`
-					rawTrackError = getShortestRadialPath(vorILSBearing, course)
-					vorILSTrackError = trackErrorRotationalSymmetry(rawTrackError)
-					if rawTrackError ~= vorILSTrackError then
-						vorDirFlag = -1
-					else
-						vorDirFlag = 1
-					end
+                    -- Set track error, same as above but for `course`
+                    rawTrackError = getShortestRadialPath(vorILSBearing, course)
+                    vorILSTrackError = trackErrorRotationalSymmetry(rawTrackError)
+                    if rawTrackError ~= vorILSTrackError then
+                        vorDirFlag = -1
+                    else
+                        vorDirFlag = 1
+                    end
                 end
             end
         end
@@ -592,8 +592,7 @@ end
 
 function updateVORDirFlag()
     if (validVOR and vorModeOn) or (validILS and ilsModeOn) then
-        --if vorILSTrackError > 90 or vorILSTrackError < -90 then
-		if vorDirFlag == -1 then
+        if vorDirFlag == -1 then
             paramHSIVorToFrom:set(-1)
         else
             paramHSIVorToFrom:set(1)


### PR DESCRIPTION
Course deviation bar would snap to full deflection upon crossing 180deg opposite the selected course. This solution checks for the course error to reach +90 or -90 degrees, then applies math so that as the actual course error strays further, the calculated course error decreases back towards 0. This fix also applies the same behavior to the VSI course deviation indicator.

Fixes issue:
#102 