### PR TITLE
Fix APR39 filename typo

### DIFF
--- a/Cockpit/Scripts/APR39/device/tables.lua
+++ b/Cockpit/Scripts/APR39/device/tables.lua
@@ -128,7 +128,7 @@ wordlist =
 		param = "SND_INST_APR39_ACQUISITION"
 	},
 	[2] = {
-		name = "ap39failure",
+		name = "apr39failure",
 		length = 2,
 		param = "SND_INST_APR39_FAILURE"
 	},

--- a/Cockpit/Scripts/Systems/sound_system.lua
+++ b/Cockpit/Scripts/Systems/sound_system.lua
@@ -58,7 +58,7 @@ function post_initialize()
 
         -- APR-39
         Sound_Player(sndhost_cockpit, "APR39/acquisition", "SND_INST_APR39_ACQUISITION", SOUND_ONCE),
-        Sound_Player(sndhost_cockpit, "APR39/ap39failure", "SND_INST_APR39_FAILURE", SOUND_ONCE),
+        Sound_Player(sndhost_cockpit, "APR39/apr39failure", "SND_INST_APR39_FAILURE", SOUND_ONCE),
         Sound_Player(sndhost_cockpit, "APR39/apr39operational", "SND_INST_APR39_OPERATIONAL", SOUND_ONCE),
         Sound_Player(sndhost_cockpit, "APR39/apr39powerup", "SND_INST_APR39_POWERUP", SOUND_ONCE),
         Sound_Player(sndhost_cockpit, "APR39/eight", "SND_INST_APR39_EIGHT", SOUND_ONCE),


### PR DESCRIPTION
Fixes a simple typo with apr39failure which was creating errors in the log file. Resolves issue #235.